### PR TITLE
feat: KOTLPlayerEnterArenaEvent and KOTLPlayerLeaveArenaEvent

### DIFF
--- a/src/main/java/me/despical/kotl/api/events/player/KOTLPlayerEnterArenaEvent.java
+++ b/src/main/java/me/despical/kotl/api/events/player/KOTLPlayerEnterArenaEvent.java
@@ -1,0 +1,55 @@
+/*
+ * KOTL - Don't let others to climb top of the ladders!
+ * Copyright (C) 2023 Despical
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package me.despical.kotl.api.events.player;
+
+import me.despical.kotl.api.events.KOTLEvent;
+import me.despical.kotl.arena.Arena;
+import org.bukkit.entity.Player;
+import org.bukkit.event.HandlerList;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * @author HappyAreaBean
+ * @since 2.7.9
+ * <p>
+ * Created at 02.01.2024
+ */
+public class KOTLPlayerEnterArenaEvent extends KOTLEvent {
+
+	private static final HandlerList handlers = new HandlerList();
+	private final Player player;
+
+	public KOTLPlayerEnterArenaEvent(Arena eventArena, Player player) {
+		super(eventArena);
+		this.player = player;
+	}
+
+	public static HandlerList getHandlerList() {
+		return handlers;
+	}
+
+	@Override
+	public @NotNull HandlerList getHandlers() {
+		return handlers;
+	}
+
+	public Player getPlayer() {
+		return player;
+	}
+}

--- a/src/main/java/me/despical/kotl/api/events/player/KOTLPlayerLeaveArenaEvent.java
+++ b/src/main/java/me/despical/kotl/api/events/player/KOTLPlayerLeaveArenaEvent.java
@@ -1,0 +1,55 @@
+/*
+ * KOTL - Don't let others to climb top of the ladders!
+ * Copyright (C) 2023 Despical
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package me.despical.kotl.api.events.player;
+
+import me.despical.kotl.api.events.KOTLEvent;
+import me.despical.kotl.arena.Arena;
+import org.bukkit.entity.Player;
+import org.bukkit.event.HandlerList;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * @author HappyAreaBean
+ * @since 2.7.9
+ * <p>
+ * Created at 02.01.2024
+ */
+public class KOTLPlayerLeaveArenaEvent extends KOTLEvent {
+
+	private static final HandlerList handlers = new HandlerList();
+	private final Player player;
+
+	public KOTLPlayerLeaveArenaEvent(Arena eventArena, Player player) {
+		super(eventArena);
+		this.player = player;
+	}
+
+	public static HandlerList getHandlerList() {
+		return handlers;
+	}
+
+	@Override
+	public @NotNull HandlerList getHandlers() {
+		return handlers;
+	}
+
+	public Player getPlayer() {
+		return player;
+	}
+}

--- a/src/main/java/me/despical/kotl/arena/Arena.java
+++ b/src/main/java/me/despical/kotl/arena/Arena.java
@@ -24,6 +24,8 @@ import me.despical.commons.miscellaneous.AttributeUtils;
 import me.despical.commons.serializer.InventorySerializer;
 import me.despical.kotl.ConfigPreferences;
 import me.despical.kotl.Main;
+import me.despical.kotl.api.events.player.KOTLPlayerEnterArenaEvent;
+import me.despical.kotl.api.events.player.KOTLPlayerLeaveArenaEvent;
 import me.despical.kotl.arena.managers.BossBarManager;
 import me.despical.kotl.arena.managers.ScoreboardManager;
 import me.despical.kotl.handlers.ChatManager;
@@ -303,6 +305,8 @@ public class Arena {
 
 		user.giveKit();
 		user.performReward(Reward.RewardType.JOIN);
+
+		plugin.getServer().getScheduler().runTask(plugin, () -> plugin.getServer().getPluginManager().callEvent(new KOTLPlayerEnterArenaEvent(this, player)));
 	}
 
 	public void removePlayer(Player player) {
@@ -340,6 +344,8 @@ public class Arena {
 		plugin.getUserManager().getDatabase().saveStatistics(user);
 
 		AttributeUtils.resetAttackCooldown(player);
+
+		plugin.getServer().getScheduler().runTask(plugin, () -> plugin.getServer().getPluginManager().callEvent(new KOTLPlayerLeaveArenaEvent(this, player)));
 	}
 
 	public void teleportToEndLocation(Player player) {


### PR DESCRIPTION
Hi! This PR adds `KOTLPlayerEnterArenaEvent` and `KOTLPlayerLeaveArenaEvent`.

I recently added these two events for my hub plugin to handle player PVP in the KOTL arena. I figured it'd be useful for others if they wanted to use it. So here I come :)