### PR TITLE
Fixed MySQL initialization

### DIFF
--- a/src/main/java/me/despical/kotl/user/data/MysqlManager.java
+++ b/src/main/java/me/despical/kotl/user/data/MysqlManager.java
@@ -51,6 +51,7 @@ public non-sealed class MysqlManager extends IUserDatabase {
 						  `UUID` char(36) NOT NULL PRIMARY KEY,
 						  `name` varchar(32) NOT NULL,
 						  `toursplayed` int(11) NOT NULL DEFAULT '0',
+						  `kill` int(11) NOT NULL DEFAULT '0',
 						  `score` int(11) NOT NULL DEFAULT '0'
 						);""".formatted(table));
 			} catch (SQLException exception) {


### PR DESCRIPTION
This PR simply fixes the MySQL initial table creation with adding "kill" column.